### PR TITLE
.修改了drainSchedule.go中把调度时间改为 drainbuff + time。now

### DIFF
--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -179,10 +179,16 @@ func (sg *SchedulesGroup) whenNextSchedule(failedCount int32, options *schedulin
 			period = *lastSchedule.customDrainBuffer
 		}
 		// compute next value
+		//if failedCount > 0 {
+		//	when = lastSchedule.when.Add(backoffDelay)
+		//} else {
+		//	when = lastSchedule.when.Add(period)
+		//}
+		// modify by huangtl
 		if failedCount > 0 {
-			when = lastSchedule.when.Add(backoffDelay)
+			when = time.Now().Add(backoffDelay)
 		} else {
-			when = lastSchedule.when.Add(period)
+			when = time.Now().Add(period)
 		}
 	}
 

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -594,10 +594,21 @@ func (h *DrainingResourceEventHandler) scheduleDrain(n *core.Node, failedCount i
 		h.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainSchedulingFailed, "Drain scheduling failed: %v", err)
 		return
 	}
-	log.Info("Drain scheduled ", zap.Time("after", when))
+	log.Info("Drain scheduled time: " + localTime(when))
 	tags, _ = tag.New(tags, tag.Upsert(TagResult, tagResultSucceeded)) // nolint:gosec
 	StatRecordForEachCondition(tags, n, GetNodeOffendingConditions(n, h.conditions), MeasureNodesDrainScheduled.M(1))
-	h.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainScheduled, "Will drain node after %s", when.Format(time.RFC3339Nano))
+	h.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainScheduled, "Will drain node after: %s .", localTime(when))
+
+}
+
+//modify by huangtl
+func localTime(now time.Time) string {
+	newTime := now
+	newTime = newTime.UTC().Add(8 * time.Hour)
+	year, mon, day := newTime.Date()
+	hour, min, sec := newTime.Clock()
+	return fmt.Sprintf("%d-%d-%d %02d:%02d:%02d\n",
+		year, mon, day, hour, min, sec)
 }
 
 func HasDrainRetryAnnotation(n *core.Node) bool {

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -111,7 +111,9 @@ func GetAPIResources(discoveryClient discovery.DiscoveryInterface) ([]metav1.API
 			}
 			resourceLists, err := discoveryClient.ServerResourcesForGroupVersion(gvd.GroupVersion)
 			if err != nil {
-				return nil, fmt.Errorf("cannot list server resources, %s", err)
+				//modify
+				continue
+				//return nil, fmt.Errorf("cannot list server resources, %s", err)
 			}
 
 			if resourceLists == nil {
@@ -161,7 +163,9 @@ func GetAPIResourcesForGroupsKindVersion(apiResources []metav1.APIResource, gvks
 		}
 
 		if !atLeastOneResourceFound {
-			return nil, fmt.Errorf("could not find any APIResource matching kind[.version[.group]]='%s'", gvkInput)
+			//modify
+			continue
+			//return nil, fmt.Errorf("could not find any APIResource matching kind[.version[.group]]='%s'", gvkInput)
 		}
 	}
 	return outputAPIResources, nil


### PR DESCRIPTION
.修改了eventhandler.go中发送drain time的格式从utc改为 csv
.修改了util.go中 对于一些failed apiservice暂时跳过的逻辑